### PR TITLE
feat: fix & improve color setting

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -113,9 +113,7 @@ const IfVisualizator = (props: { data?: JSON }) => {
   console.log({ imageData, dataToRender });
 
   if (dataToRender) {
-    return (
-      <Visualizator mapData={dataToRender} imageData={imageData}></Visualizator>
-    );
+    return <Visualizator mapData={dataToRender} imageData={imageData} />;
   } else {
     return null;
   }

--- a/src/components/OptionSelector/OptionSelector.tsx
+++ b/src/components/OptionSelector/OptionSelector.tsx
@@ -15,7 +15,10 @@ import CloseIcon from '@material-ui/icons/Close';
 import clsx from 'clsx';
 
 export interface IOptionSelectorProps {
-  onColorChange: (lowColor: string, highColor: string) => void;
+  lowColor: string;
+  onLowColorChange: (lowColor: string) => void;
+  highColor: string;
+  onHighColorChange: (lowColor: string) => void;
 }
 
 const useStyles = makeStyles({
@@ -84,22 +87,22 @@ const OptionSelector = (props: IOptionSelectorProps) => {
   }
 
   function onHighColorChangeComplete(color: ColorResult) {
-    setHighColor(color.hex);
+    props.onHighColorChange(color.hex);
   }
 
   function onLowColorChangeComplete(color: ColorResult) {
-    setLowColor(color.hex);
+    props.onLowColorChange(color.hex);
   }
 
   // TODO: store 1 object containing both colors
   useEffect(() => {
     localStorage.setItem('isp_highColor', highColor);
-    props.onColorChange(lowColor, highColor);
+    props.onHighColorChange(highColor);
   }, [highColor]);
 
   useEffect(() => {
     localStorage.setItem('isp_lowColor', lowColor);
-    props.onColorChange(lowColor, highColor);
+    props.onLowColorChange(lowColor);
   }, [lowColor]);
 
   return (
@@ -128,7 +131,7 @@ const OptionSelector = (props: IOptionSelectorProps) => {
                 />
                 <ChromePicker
                   onChangeComplete={onHighColorChangeComplete}
-                  color={highColor}
+                  color={props.highColor}
                 />
               </div>
             ) : null}
@@ -146,7 +149,7 @@ const OptionSelector = (props: IOptionSelectorProps) => {
                 <div className={classes.cover} onClick={toggleLowColorPicker} />
                 <ChromePicker
                   onChangeComplete={onLowColorChangeComplete}
-                  color={lowColor}
+                  color={props.lowColor}
                 />
               </div>
             ) : null}

--- a/src/components/OptionSelector/OptionSelector.tsx
+++ b/src/components/OptionSelector/OptionSelector.tsx
@@ -60,9 +60,6 @@ const OptionSelector = (props: IOptionSelectorProps) => {
   const [highColorPickerOpen, setHighColorPickerOpen] = useState(false);
   const [lowColorPickerOpen, setLowColorPickerOpen] = useState(false);
 
-  const [lowColor, setLowColor] = useState<string>(getLowColor());
-  const [highColor, setHighColor] = useState<string>(getHighColor());
-
   function openMenu() {
     setOpen(true);
   }
@@ -75,12 +72,6 @@ const OptionSelector = (props: IOptionSelectorProps) => {
   }
   function closeMenu() {
     setOpen(false);
-  }
-  function getHighColor(): string {
-    return props.highColor;
-  }
-  function getLowColor(): string {
-    return props.lowColor;
   }
 
   function onHighColorChangeComplete(color: ColorResult) {

--- a/src/components/OptionSelector/OptionSelector.tsx
+++ b/src/components/OptionSelector/OptionSelector.tsx
@@ -1,15 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import {
-  ChromePicker,
-  ColorResult,
-} from 'react-color';
+import React, { useState } from 'react';
+import { ChromePicker, ColorResult } from 'react-color';
 import {
   Paper,
   makeStyles,
   Button,
   ButtonBase,
   Typography,
-  IconButton,
+  IconButton
 } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 import clsx from 'clsx';
@@ -93,17 +90,6 @@ const OptionSelector = (props: IOptionSelectorProps) => {
   function onLowColorChangeComplete(color: ColorResult) {
     props.onLowColorChange(color.hex);
   }
-
-  // TODO: store 1 object containing both colors
-  useEffect(() => {
-    localStorage.setItem('isp_highColor', highColor);
-    props.onHighColorChange(highColor);
-  }, [highColor]);
-
-  useEffect(() => {
-    localStorage.setItem('isp_lowColor', lowColor);
-    props.onLowColorChange(lowColor);
-  }, [lowColor]);
 
   return (
     <Paper

--- a/src/components/OptionSelector/OptionSelector.tsx
+++ b/src/components/OptionSelector/OptionSelector.tsx
@@ -80,10 +80,10 @@ const OptionSelector = (props: IOptionSelectorProps) => {
     setOpen(false);
   }
   function getHighColor(): string {
-    return localStorage.getItem('isp_highColor') || '#fff';
+    return props.highColor;
   }
   function getLowColor(): string {
-    return localStorage.getItem('isp_lowColor') || '#fff';
+    return props.lowColor;
   }
 
   function onHighColorChangeComplete(color: ColorResult) {

--- a/src/components/Visualizator/Visualizator.tsx
+++ b/src/components/Visualizator/Visualizator.tsx
@@ -19,9 +19,6 @@ const Visualizator = (props: IVisualizatorProps) => {
   const [width, setWidth] = useState(getWindowWidth());
   const [height, setHeight] = useState(getWindowHeight());
 
-  const localHighColor = localStorage.getItem('isp_highColor');
-  const localLowColor = localStorage.getItem('isp_lowColor');
-
   const { lowColor, highColor, setLowColor, setHighColor } = useMapColors();
 
   const [game, setGame] = useState<IsoGame>();

--- a/src/components/Visualizator/Visualizator.tsx
+++ b/src/components/Visualizator/Visualizator.tsx
@@ -3,6 +3,7 @@ import Phaser from 'phaser';
 import IsoGame from './lib/IsoGame';
 import { HeightMapScene } from './lib/scenes/heightMapScene';
 import OptionSelector from '../OptionSelector/OptionSelector';
+import { useMapColors } from '../../hooks';
 
 interface IVisualizatorProps {
   mapData: JSON;
@@ -20,6 +21,9 @@ const Visualizator = (props: IVisualizatorProps) => {
 
   const localHighColor = localStorage.getItem('isp_highColor');
   const localLowColor = localStorage.getItem('isp_lowColor');
+
+  const { lowColor, highColor, setLowColor, setHighColor } = useMapColors();
+
   const [game, setGame] = useState<IsoGame>();
   // FIXME
   const [gameContainerBounds, setGameContainerBounds] = useState<any>({
@@ -32,8 +36,8 @@ const Visualizator = (props: IVisualizatorProps) => {
   const scene = new HeightMapScene({
     data: props.mapData,
     imageBase64: props.imageData,
-    lowColor: localLowColor,
-    highColor: localHighColor
+    lowColor,
+    highColor
   });
 
   useEffect(() => {
@@ -129,7 +133,14 @@ const Visualizator = (props: IVisualizatorProps) => {
         />
       )} */}
       <div id="display-el"></div>
-      {game && <OptionSelector onColorChange={handleColorChange} />}
+      {game && (
+        <OptionSelector
+          lowColor={lowColor}
+          highColor={highColor}
+          onLowColorChange={setLowColor}
+          onHighColorChange={setHighColor}
+        />
+      )}
     </>
   );
 };

--- a/src/components/Visualizator/Visualizator.tsx
+++ b/src/components/Visualizator/Visualizator.tsx
@@ -86,11 +86,11 @@ const Visualizator = (props: IVisualizatorProps) => {
     }
   }, [game]);
 
-  function handleColorChange(lowColor: string, highColor: string) {
+  useEffect(() => {
     if (game) {
       game.colorChanged(lowColor, highColor);
     }
-  }
+  }, [game, lowColor, highColor]);
 
   return (
     <>

--- a/src/components/Visualizator/Visualizator.tsx
+++ b/src/components/Visualizator/Visualizator.tsx
@@ -19,7 +19,10 @@ const Visualizator = (props: IVisualizatorProps) => {
   const [width, setWidth] = useState(getWindowWidth());
   const [height, setHeight] = useState(getWindowHeight());
 
-  const { lowColor, highColor, setLowColor, setHighColor } = useMapColors();
+  const { lowColor, highColor, setLowColor, setHighColor } = useMapColors({
+    defaultLowColor: '#ffffff',
+    defaultHighColor: '#bada55'
+  });
 
   const [game, setGame] = useState<IsoGame>();
   // FIXME

--- a/src/components/Visualizator/Visualizator.tsx
+++ b/src/components/Visualizator/Visualizator.tsx
@@ -94,18 +94,6 @@ const Visualizator = (props: IVisualizatorProps) => {
 
   return (
     <>
-      <div
-        style={{
-          position: 'absolute',
-          background: 'white',
-          width: '300px',
-          height: '100px',
-          fontSize: '10px',
-          padding: '10px'
-        }}
-      >
-        {JSON.stringify(gameContainerBounds)}
-      </div>
       {/* TEMP */}
       {props.imageData && game !== null && (
         <img

--- a/src/components/Visualizator/lib/scenes/heightMapScene.ts
+++ b/src/components/Visualizator/lib/scenes/heightMapScene.ts
@@ -128,14 +128,13 @@ export class HeightMapScene extends Phaser.Scene {
       const halfWidth = this.width / 2;
       const height = singleGridData.height;
       const t = (height - this.minHeight) / (this.maxHeight - this.minHeight);
-      /*
-     let color: Color;
+
+      let color: Color;
       if (height === 0) {
         color = this.waterColor;
       } else {
         color = this.lowColor.lerpTo(this.highColor, t);
       }
-      */
 
       var tx = (x - y) * halfWidth * 0.6;
       var ty = (x + y) * halfDepth * 0.6;
@@ -144,7 +143,7 @@ export class HeightMapScene extends Phaser.Scene {
         new Phaser.Geom.Point(this.centerX + tx, this.centerY + ty),
         0,
         this.size,
-        this.lowColor,
+        color,
         this
       );
 
@@ -167,7 +166,7 @@ export class HeightMapScene extends Phaser.Scene {
         delay: reverseIndex * 2,
         onUpdate: (args) => {
           const animationProgress = args.elapsed / args.duration;
-          // this.updateCubeColor(cube, this.lowColor, color, animationProgress);
+          this.updateCubeColor(cube, this.lowColor, color, animationProgress);
         }
       });
     }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useMapColors } from './useMapColors';

--- a/src/hooks/useMapColors.ts
+++ b/src/hooks/useMapColors.ts
@@ -8,8 +8,12 @@ type UseMapColorsReturnProps = {
 };
 
 export function useMapColors(): UseMapColorsReturnProps {
-  const [lowColor, setLowColor] = useState<string>('');
-  const [highColor, setHighColor] = useState<string>('');
+  const [lowColor, setLowColor] = useState<string>(
+    localStorage.getItem('isp_lowColor') ?? '#fff'
+  );
+  const [highColor, setHighColor] = useState<string>(
+    localStorage.getItem('isp_highColor') ?? '#fff'
+  );
 
   return {
     lowColor,

--- a/src/hooks/useMapColors.ts
+++ b/src/hooks/useMapColors.ts
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+
+type UseMapColorsReturnProps = {
+  lowColor: string;
+  highColor: string;
+  setLowColor: (lowColor: string) => void;
+  setHighColor: (highColor: string) => void;
+};
+
+export function useMapColors(): UseMapColorsReturnProps {
+  const [lowColor, setLowColor] = useState<string>('');
+  const [highColor, setHighColor] = useState<string>('');
+
+  return {
+    lowColor,
+    highColor,
+    setLowColor,
+    setHighColor
+  };
+}

--- a/src/hooks/useMapColors.ts
+++ b/src/hooks/useMapColors.ts
@@ -9,10 +9,10 @@ type UseMapColorsReturnProps = {
 
 export function useMapColors(): UseMapColorsReturnProps {
   const [lowColor, setLowColor] = useState<string>(
-    localStorage.getItem('isp_lowColor') ?? '#fff'
+    localStorage.getItem('isp_lowColor') ?? '#ffffff'
   );
   const [highColor, setHighColor] = useState<string>(
-    localStorage.getItem('isp_highColor') ?? '#fff'
+    localStorage.getItem('isp_highColor') ?? '#bada55'
   );
 
   useEffect(() => {

--- a/src/hooks/useMapColors.ts
+++ b/src/hooks/useMapColors.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 type UseMapColorsReturnProps = {
   lowColor: string;
@@ -14,6 +14,14 @@ export function useMapColors(): UseMapColorsReturnProps {
   const [highColor, setHighColor] = useState<string>(
     localStorage.getItem('isp_highColor') ?? '#fff'
   );
+
+  useEffect(() => {
+    localStorage.setItem('isp_lowColor', lowColor);
+  }, [lowColor]);
+
+  useEffect(() => {
+    localStorage.setItem('isp_highColor', highColor);
+  }, [highColor]);
 
   return {
     lowColor,

--- a/src/hooks/useMapColors.ts
+++ b/src/hooks/useMapColors.ts
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react';
 
+type UseMapColorsProps = {
+  defaultLowColor: string;
+  defaultHighColor: string;
+};
+
 type UseMapColorsReturnProps = {
   lowColor: string;
   highColor: string;
@@ -7,12 +12,14 @@ type UseMapColorsReturnProps = {
   setHighColor: (highColor: string) => void;
 };
 
-export function useMapColors(): UseMapColorsReturnProps {
+export function useMapColors(
+  props: UseMapColorsProps
+): UseMapColorsReturnProps {
   const [lowColor, setLowColor] = useState<string>(
-    localStorage.getItem('isp_lowColor') ?? '#ffffff'
+    localStorage.getItem('isp_lowColor') ?? props.defaultLowColor
   );
   const [highColor, setHighColor] = useState<string>(
-    localStorage.getItem('isp_highColor') ?? '#bada55'
+    localStorage.getItem('isp_highColor') ?? props.defaultHighColor
   );
 
   useEffect(() => {


### PR DESCRIPTION
# Description

There are a few things to fix when it comes to color handling:
- colors are not centralized
- default colors don't work (default values are `#fff`, but colors are only parsed when expressed in 6 characters)

## Changes

In order to clean this up, I had to:
- make `OptionSelector` a controlled component
- add a new hook `useMapColors`

As a bonus:
- a bit of cleaning up :broom: 

## What's next

- next time, write a ticket to explain what you want to do before doing it
- speaking of tickets, this one is somehow related: https://github.com/Les-Marabouts-du-Code/isometric-3d-playground/issues/36